### PR TITLE
ipynb: hola_mundo; intro

### DIFF
--- a/examples-ipynb/py01_hola_mundo/hola_mundo.ipynb
+++ b/examples-ipynb/py01_hola_mundo/hola_mundo.ipynb
@@ -1,0 +1,33 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Mostramos en consola la cadena: Hola Mundo\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('Hola Mundo')\n"
+   ]
+  }
+ ]
+}

--- a/examples-ipynb/py01_hola_mundo/hola_mundo_lab_01.ipynb
+++ b/examples-ipynb/py01_hola_mundo/hola_mundo_lab_01.ipynb
@@ -1,0 +1,33 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Mostramos en consola la cadena: ¡Hola Mundo!\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"¡Hola Mundo!\")\n"
+   ]
+  }
+ ]
+}

--- a/examples-ipynb/py02_intro/comentarios_segundos.ipynb
+++ b/examples-ipynb/py02_intro/comentarios_segundos.ipynb
@@ -1,0 +1,47 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Comentario de línea\n",
+    "Este programa calcula los segundos en cierto número de horas determinadas\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "days = 2  # Comentario en línea\n",
+    "horas = 2  # Número de horas\n",
+    "segundos_hora = 3600  # Número de segundos en una hora\n",
+    "\n",
+    "print(\"Horas:\", horas)  # Imprime el número de horas\n",
+    "print(\"En\", horas, \"horas, hay:\", horas * segundos_hora, 'segundos.')  # Imprime la cantidad de segundos en las horas\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Esto es un comentario que abarca múltiples líneas.\n",
+    "Aquí tenemos el fin del programa que calcula el número de segundos en 2 horas\n"
+   ]
+  }
+ ]
+}

--- a/examples-ipynb/py02_intro/input_01_intro.ipynb
+++ b/examples-ipynb/py02_intro/input_01_intro.ipynb
@@ -1,0 +1,89 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Solicitamos el primer número\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('Buen día! Ingrese el primer número:', end=' ****> ')\n",
+    "primera_cadena = input()\n",
+    "\n",
+    "print('\\n\\n', primera_cadena, type(primera_cadena))\n",
+    "\n",
+    "primer_numero = int(primera_cadena)  # Cambiamos el tipo de datos de cadena de caracteres (str) a número entero (int)\n",
+    "print(primer_numero, type(primer_numero))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Solicitamos el segundo número\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('Ahora, por favor, ingrese el segundo número:', end=\" \")\n",
+    "segunda_cadena = input()\n",
+    "segundo_numero = int(segunda_cadena)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Calculamos el resultado\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "resultado = primer_numero + segundo_numero\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Mostramos el resultado\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('La suma de ambos números es igual a:', resultado)\n"
+   ]
+  }
+ ]
+}

--- a/examples-ipynb/py02_intro/input_02_int_float_str.ipynb
+++ b/examples-ipynb/py02_intro/input_02_int_float_str.ipynb
@@ -1,0 +1,90 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "La sentencia input siempre nos devuelve una cadena\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# cadena = input('Introduce una cadena de texto: ')\n",
+    "# print('La cadena de texto que ingreso es:', cadena)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "# Para introducir un número entero utilizamos la función integrada int()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# numero_entero = int(input('Introduce un numero entero: '))\n",
+    "# print('El numero entero que ingreso es:', numero_entero)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Para introducir un número decimal utilizamos la función integrada float()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "numero_decimal = float(input('Introduce un numero decimal: '))\n",
+    "print('El numero decimal que ingreso es:', numero_decimal)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Para convertir un número en cadena utilizamos la función integrada str()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nueva_cadena = str(numero_decimal)\n",
+    "print(\"El número convertido en cadena es:\", nueva_cadena)\n",
+    "\n",
+    "# int() a entero\n",
+    "# float() a decimal\n",
+    "# str() a cadena\n"
+   ]
+  }
+ ]
+}

--- a/examples-ipynb/py02_intro/operadores_01_matematicos_basicos.ipynb
+++ b/examples-ipynb/py02_intro/operadores_01_matematicos_basicos.ipynb
@@ -1,0 +1,66 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Operadores matemáticos básicos\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "num_a = int(input('ingrese el primer número: '))\n",
+    "num_b = float(input('ingrese el segundo número: '))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Realizamos las operaciones\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(num_a + num_b, 'Resultado de la Suma')\n",
+    "print(num_a - num_b, 'Resultado de la Resta')\n",
+    "print(num_a * num_b, 'Resultado de la Multiplicación')\n",
+    "print(num_a / num_b, 'Resultado de la División decimal (flot)')\n",
+    "print(num_a % num_b, 'Resultado del Módulo, resultado el resto de la división entero')\n",
+    "print(num_a // num_b, 'Resultado de la División Entera')\n",
+    "print(num_a ** num_b, 'Resultado de la Potencia')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Pruebas\n",
+    "- Ejecuta este scrip ingresando distintos números\n",
+    "- Cambia una de las funciones int() por float(). ¿Qué observas?\n",
+    "- Ingresa 0 (cero) como segundo número. ¿Qué sucede?\n"
+   ]
+  }
+ ]
+}

--- a/examples-ipynb/py02_intro/operadores_02_orden_prioridades.ipynb
+++ b/examples-ipynb/py02_intro/operadores_02_orden_prioridades.ipynb
@@ -1,0 +1,45 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Los paréntesis () modifican el orden de las operaciones\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(14 + 15 * 3 - 16 / 4)\n",
+    "print(14 + 15 * (3 - 16) / 4)\n",
+    "print((14 + 15) * (3 - 16) / 4)\n",
+    "print((14 + 15) * 3 - 16 / 4)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Suma de enteros tiene com resultado un entero\n",
+    "Suma de enteros + decimal tiene como resultado un decimal\n",
+    "Suma de decimales tiene como resultado un decimal"
+   ]
+  }
+ ]
+}

--- a/examples-ipynb/py02_intro/print_01_escape_nueva_linea.ipynb
+++ b/examples-ipynb/py02_intro/print_01_escape_nueva_linea.ipynb
@@ -1,0 +1,66 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "La \\ es un carácter de escape (Slash o Barra lateral)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# print('Fragmento de la Zamba: \"Mujer, Niña y Amiga\"')  # Utilizamos ' para poder mostrar \" dentro de la cadena\n",
+    "# print(\"Autor: \\\"Hernán Figueroa Reyes\\\"\")  # Utilizamos el signo de escape para poder mostrar el carácter \"\n",
+    "# print(\"Cantautor Salteño \\\\\\\\ 1936-1976\")  # Utilizamos el signo de escape para poder mostrar el carácter \\\n",
+    "# print('Note: I\\'m \"Salteño\", I love Salta')  # Utilizamos el signo de escape para poder mostrar el carácter '\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Realizamos un salto de línea con la secuencia \\n\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"\\nDéjame soñar contigo en esta noche\\nquiero yo encender luceros en cielo,\")\n",
+    "print(\"para grabar tu nombre en cada estrella\\npara gritar lo mucho que te quiero.\")\n",
+    "\n",
+    "print('''\n",
+    "Informe\n",
+    "\n",
+    "Déjame soñar contigo en esta noche\n",
+    "quiero yo encender luceros en cielo\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    ")\n"
+   ]
+  }
+ ]
+}

--- a/examples-ipynb/py02_intro/variables_01_intro.ipynb
+++ b/examples-ipynb/py02_intro/variables_01_intro.ipynb
@@ -1,0 +1,93 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Variables numéricas\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ingreso_semanal = 20\n",
+    "egreso_semanal = 10\n",
+    "semanas_anuales = 52\n",
+    "\n",
+    "# print(ingreso_semanal / egreso_semanal)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Variables de texto\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mi_nombre = \"Héctor\"\n",
+    "mi_apellido = \"Chocobar Torrejón\"\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Realizamos una operación matemática dentro del print (segundo parámetro) y lo mostramos\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# print('Ahorro Anual:', (ingreso_semanal - egreso_semanal) * semanas_anuales)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Tres parámetros: string, variable de texto, variable de texto.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('Mi nombre:', mi_nombre, mi_apellido, 28 * 2 , 'ingreso semanal:', ingreso_semanal, egreso_semanal, semanas_anuales)\n"
+   ]
+  }
+ ]
+}

--- a/examples-ipynb/py02_intro/variables_02_tipos_de_datos.ipynb
+++ b/examples-ipynb/py02_intro/variables_02_tipos_de_datos.ipynb
@@ -1,0 +1,167 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Cadena de texto (string)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mi_cadena = \"Hola Mundo!\"\n",
+    "mi_cadena_larga = \"\"\"\n",
+    "Esta es una cadena\n",
+    "de varias lineas \"\"\"\n",
+    "\n",
+    "print(mi_cadena)\n",
+    "print(mi_cadena_larga)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Número entero decimal\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "edad = 35\n",
+    "numero_grande1 = 35E4\n",
+    "numero_grande2 = 35e8\n",
+    "# print(numero_grande1, numero_grande2, type(numero_grande1))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Número entero octal\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "numero_octal1 = 0o10\n",
+    "numero_octal2 = 0O20\n",
+    "# print(numero_octal1, numero_octal2, type(numero_octal1))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Número entero hexadecimal\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "numero_hexadecimal1 = 0x15\n",
+    "numero_hexadecimal2 = 0X2F\n",
+    "# print(numero_hexadecimal1, numero_hexadecimal2, type(numero_hexadecimal1))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Número real o de punto flotante\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "precio1 = 7435.28\n",
+    "precio2 = 74.\n",
+    "porcentaje = .4\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Booleano: verdadero / falso\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "verdadero = True\n",
+    "falso = False\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "None – NonType – Ausencia de un valor\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "variable_sin_nada = None\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "La función integrada type() nos devuelve el tipo de dato que contiene la variable\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(type(mi_cadena))\n",
+    "print(type(mi_cadena_larga))\n",
+    "print(type(edad))\n",
+    "print(type(numero_grande1))\n",
+    "print(numero_grande1)\n",
+    "print(type(numero_octal1))\n",
+    "print(type(numero_hexadecimal1))\n"
+   ]
+  }
+ ]
+}


### PR DESCRIPTION
Closes #78

Convierte los archivos .py de `examples/py01_hola_mundo` y `examples/py02_intro` a notebooks Jupyter en `examples-ipynb/`.

- Separa comentarios en celdas markdown y código en celdas code
- Detecta comentarios de código comentado y los incluye en celdas code
- Preserva docstrings como contenido markdown

**Contenido:**
- `examples-ipynb/py01_hola_mundo/` — 2 notebooks
- `examples-ipynb/py02_intro/` — 8 notebooks (print, input, variables, operadores, comentarios)